### PR TITLE
Feat: Issue #5: Integrate schema matching with existing code

### DIFF
--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -116,6 +116,7 @@ public final class Gson {
   static final FieldNamingStrategy DEFAULT_FIELD_NAMING_STRATEGY = FieldNamingPolicy.IDENTITY;
   static final ToNumberStrategy DEFAULT_OBJECT_TO_NUMBER_STRATEGY = ToNumberPolicy.DOUBLE;
   static final ToNumberStrategy DEFAULT_NUMBER_TO_NUMBER_STRATEGY = ToNumberPolicy.LAZILY_PARSED_NUMBER;
+  static final JsonSchemaMatcher DEFAULT_JSON_SCHEMA_MATCHER = JsonSchemaMatcher.ALLOW_EVERYTHING;
 
   private static final TypeToken<?> NULL_KEY_SURROGATE = TypeToken.get(Object.class);
   private static final String JSON_NON_EXECUTABLE_PREFIX = ")]}'\n";
@@ -156,6 +157,7 @@ public final class Gson {
   final List<TypeAdapterFactory> builderHierarchyFactories;
   final ToNumberStrategy objectToNumberStrategy;
   final ToNumberStrategy numberToNumberStrategy;
+  final JsonSchemaMatcher schemaMatcher;
 
   /**
    * Constructs a Gson object with default configuration. The default configuration has the
@@ -199,7 +201,8 @@ public final class Gson {
         DEFAULT_USE_JDK_UNSAFE,
         LongSerializationPolicy.DEFAULT, DEFAULT_DATE_PATTERN, DateFormat.DEFAULT, DateFormat.DEFAULT,
         Collections.<TypeAdapterFactory>emptyList(), Collections.<TypeAdapterFactory>emptyList(),
-        Collections.<TypeAdapterFactory>emptyList(), DEFAULT_OBJECT_TO_NUMBER_STRATEGY, DEFAULT_NUMBER_TO_NUMBER_STRATEGY);
+        Collections.<TypeAdapterFactory>emptyList(), DEFAULT_OBJECT_TO_NUMBER_STRATEGY, DEFAULT_NUMBER_TO_NUMBER_STRATEGY,
+        DEFAULT_JSON_SCHEMA_MATCHER);
   }
 
   Gson(Excluder excluder, FieldNamingStrategy fieldNamingStrategy,
@@ -211,7 +214,8 @@ public final class Gson {
       int timeStyle, List<TypeAdapterFactory> builderFactories,
       List<TypeAdapterFactory> builderHierarchyFactories,
       List<TypeAdapterFactory> factoriesToBeAdded,
-      ToNumberStrategy objectToNumberStrategy, ToNumberStrategy numberToNumberStrategy) {
+      ToNumberStrategy objectToNumberStrategy, ToNumberStrategy numberToNumberStrategy,
+      JsonSchemaMatcher schemaMatcher) {
     this.excluder = excluder;
     this.fieldNamingStrategy = fieldNamingStrategy;
     this.instanceCreators = instanceCreators;
@@ -232,6 +236,7 @@ public final class Gson {
     this.builderHierarchyFactories = builderHierarchyFactories;
     this.objectToNumberStrategy = objectToNumberStrategy;
     this.numberToNumberStrategy = numberToNumberStrategy;
+    this.schemaMatcher = schemaMatcher;
 
     List<TypeAdapterFactory> factories = new ArrayList<TypeAdapterFactory>();
 
@@ -1060,6 +1065,15 @@ public final class Gson {
       return null;
     }
     return (T) fromJson(new JsonTreeReader(json), typeOfT);
+  }
+
+  /**
+   * Checks whether the provided JSON instance matches the schema currently associated with this Gson object.
+   * @param instance a JSON element to be matched against the schema
+   * @return true if the instance matches the schema
+   */
+  public boolean matchesSchema(JsonElement instance) {
+    return schemaMatcher.matches(instance);
   }
 
   static class FutureTypeAdapter<T> extends TypeAdapter<T> {

--- a/gson/src/main/java/com/google/gson/Gson.java
+++ b/gson/src/main/java/com/google/gson/Gson.java
@@ -1069,6 +1069,7 @@ public final class Gson {
 
   /**
    * Checks whether the provided JSON instance matches the schema currently associated with this Gson object.
+   *
    * @param instance a JSON element to be matched against the schema
    * @return true if the instance matches the schema
    */

--- a/gson/src/main/java/com/google/gson/GsonBuilder.java
+++ b/gson/src/main/java/com/google/gson/GsonBuilder.java
@@ -34,17 +34,7 @@ import com.google.gson.internal.sql.SqlTypesSupport;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 
-import static com.google.gson.Gson.DEFAULT_COMPLEX_MAP_KEYS;
-import static com.google.gson.Gson.DEFAULT_DATE_PATTERN;
-import static com.google.gson.Gson.DEFAULT_ESCAPE_HTML;
-import static com.google.gson.Gson.DEFAULT_JSON_NON_EXECUTABLE;
-import static com.google.gson.Gson.DEFAULT_LENIENT;
-import static com.google.gson.Gson.DEFAULT_NUMBER_TO_NUMBER_STRATEGY;
-import static com.google.gson.Gson.DEFAULT_OBJECT_TO_NUMBER_STRATEGY;
-import static com.google.gson.Gson.DEFAULT_PRETTY_PRINT;
-import static com.google.gson.Gson.DEFAULT_SERIALIZE_NULLS;
-import static com.google.gson.Gson.DEFAULT_SPECIALIZE_FLOAT_VALUES;
-import static com.google.gson.Gson.DEFAULT_USE_JDK_UNSAFE;
+import static com.google.gson.Gson.*;
 
 /**
  * <p>Use this builder to construct a {@link Gson} instance when you need to set configuration
@@ -101,6 +91,7 @@ public final class GsonBuilder {
   private boolean useJdkUnsafe = DEFAULT_USE_JDK_UNSAFE;
   private ToNumberStrategy objectToNumberStrategy = DEFAULT_OBJECT_TO_NUMBER_STRATEGY;
   private ToNumberStrategy numberToNumberStrategy = DEFAULT_NUMBER_TO_NUMBER_STRATEGY;
+  private JsonSchemaMatcher schemaMatcher = DEFAULT_JSON_SCHEMA_MATCHER;
 
   /**
    * Creates a GsonBuilder instance that can be used to build Gson with various configuration
@@ -137,6 +128,7 @@ public final class GsonBuilder {
     this.useJdkUnsafe = gson.useJdkUnsafe;
     this.objectToNumberStrategy = gson.objectToNumberStrategy;
     this.numberToNumberStrategy = gson.numberToNumberStrategy;
+    this.schemaMatcher = gson.schemaMatcher;
   }
 
   /**
@@ -375,6 +367,27 @@ public final class GsonBuilder {
       excluder = excluder.withExclusionStrategy(strategy, true, true);
     }
     return this;
+  }
+
+  /**
+   * Sets the Gson schema matcher that is used to verify JSON with the Gson.matchesSchema() method.
+   *
+   * @param schemaMatcher an instance of a JsonSchemaMatcher
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+  public GsonBuilder setSchemaMatcher(JsonSchemaMatcher schemaMatcher) {
+    this.schemaMatcher = schemaMatcher;
+    return this;
+  }
+
+  /**
+   * Disables the schema matcher. This is equivalent to setting the schema matcher to the "true" schema, i.e. allowing
+   * every schema.
+   *
+   * @return a reference to this {@code GsonBuilder} object to fulfill the "Builder" pattern
+   */
+  public GsonBuilder disableSchemaMatcher() {
+    return setSchemaMatcher(DEFAULT_JSON_SCHEMA_MATCHER);
   }
 
   /**
@@ -654,7 +667,8 @@ public final class GsonBuilder {
         generateNonExecutableJson, escapeHtmlChars, prettyPrinting, lenient,
         serializeSpecialFloatingPointValues, useJdkUnsafe, longSerializationPolicy,
         datePattern, dateStyle, timeStyle,
-        this.factories, this.hierarchyFactories, factories, objectToNumberStrategy, numberToNumberStrategy);
+        this.factories, this.hierarchyFactories, factories, objectToNumberStrategy, numberToNumberStrategy,
+        schemaMatcher);
   }
 
   private void addTypeAdaptersForDate(String datePattern, int dateStyle, int timeStyle,

--- a/gson/src/main/java/com/google/gson/JsonSchemaMatcher.java
+++ b/gson/src/main/java/com/google/gson/JsonSchemaMatcher.java
@@ -11,6 +11,9 @@ import java.util.Set;
  */
 public class JsonSchemaMatcher {
 
+  // The "true" schema matches any valid JSON
+  static final JsonSchemaMatcher ALLOW_EVERYTHING = new JsonSchemaMatcher("true");
+
   // The root of the schema file can be either a JSON object or a Boolean.
   private final JsonElement schemaRoot;
 

--- a/gson/src/test/java/com/google/gson/GsonTest.java
+++ b/gson/src/test/java/com/google/gson/GsonTest.java
@@ -56,7 +56,8 @@ public final class GsonTest extends TestCase {
         true, true, false, true, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>(),
-        CUSTOM_OBJECT_TO_NUMBER_STRATEGY, CUSTOM_NUMBER_TO_NUMBER_STRATEGY);
+        CUSTOM_OBJECT_TO_NUMBER_STRATEGY, CUSTOM_NUMBER_TO_NUMBER_STRATEGY,
+        Gson.DEFAULT_JSON_SCHEMA_MATCHER);
 
     assertEquals(CUSTOM_EXCLUDER, gson.excluder);
     assertEquals(CUSTOM_FIELD_NAMING_STRATEGY, gson.fieldNamingStrategy());
@@ -70,7 +71,8 @@ public final class GsonTest extends TestCase {
         true, true, false, true, LongSerializationPolicy.DEFAULT, null, DateFormat.DEFAULT,
         DateFormat.DEFAULT, new ArrayList<TypeAdapterFactory>(),
         new ArrayList<TypeAdapterFactory>(), new ArrayList<TypeAdapterFactory>(),
-        CUSTOM_OBJECT_TO_NUMBER_STRATEGY, CUSTOM_NUMBER_TO_NUMBER_STRATEGY);
+        CUSTOM_OBJECT_TO_NUMBER_STRATEGY, CUSTOM_NUMBER_TO_NUMBER_STRATEGY,
+        Gson.DEFAULT_JSON_SCHEMA_MATCHER);
 
     Gson clone = original.newBuilder()
         .registerTypeAdapter(Object.class, new TestTypeAdapter())
@@ -151,5 +153,33 @@ public final class GsonTest extends TestCase {
       .newJsonReader(new StringReader(json));
     assertEquals("test", jsonReader.nextString());
     jsonReader.close();
+  }
+
+  public void testSchemaMatcherFailing() {
+    JsonSchemaMatcher matcher = new JsonSchemaMatcher("false");
+    JsonElement instance = JsonParser.parseString("{\"foo\": \"bar\"}");
+    Gson gson = new GsonBuilder()
+            .setSchemaMatcher(matcher)
+            .create();
+    assertFalse(gson.matchesSchema(instance));
+  }
+
+  public void testSchemaMatcherSuccess() {
+    JsonSchemaMatcher matcher = new JsonSchemaMatcher("true");
+    JsonElement instance = JsonParser.parseString("{\"foo\": \"bar\"}");
+    Gson gson = new GsonBuilder()
+            .setSchemaMatcher(matcher)
+            .create();
+    assertTrue(gson.matchesSchema(instance));
+  }
+
+  public void testDisableSchemaMatcher() {
+    JsonSchemaMatcher matcher = new JsonSchemaMatcher("false");
+    JsonElement instance = JsonParser.parseString("{\"foo\": \"bar\"}");
+    Gson gson = new GsonBuilder()
+            .setSchemaMatcher(matcher)
+            .disableSchemaMatcher()
+            .create();
+    assertTrue(gson.matchesSchema(instance));
   }
 }


### PR DESCRIPTION
A schema is added to the Gson object by first setting the schema in
the GsonBuilder. Then it is possible to match already parsed JSON
against this schema by running the `matchesSchema` method.